### PR TITLE
Requiere Git durante la etapa build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM node:10.16.2-alpine as build-stage
 COPY . .
 WORKDIR /
+RUN apk update && apk upgrade && \
+    apk add --no-cache git
 RUN npm install
 RUN npm uninstall node-sass
 RUN npm install node-sass


### PR DESCRIPTION
El comando "npm install" necesita del comando "git" para descargar alguna de las librerias. 